### PR TITLE
**feat(clipboard): native “Copy as Files” (Windows/WSL bridge + GNOME…

### DIFF
--- a/graph_fs/api/__init__.py
+++ b/graph_fs/api/__init__.py
@@ -1,2 +1,3 @@
-# Ensure routes are registered on import.
-from . import routes  # noqa: F401
+from . import routes           # noqa: F401
+from . import zip_routes       # noqa: F401
+from . import clipboard_routes # noqa: F401   # ← add this line

--- a/graph_fs/api/clipboard_routes.py
+++ b/graph_fs/api/clipboard_routes.py
@@ -1,0 +1,122 @@
+import os, sys, subprocess, platform
+from flask import request, jsonify
+from ..server import app, fs, _ok, _err
+
+# ---------- utils -------------------------------------------------------------
+
+def _resolve_files(paths):
+    out = []
+    for p in paths:
+        try:
+            rp = fs.resolve(p)
+            if os.path.isfile(rp):
+                out.append(os.path.abspath(rp))
+        except Exception:
+            pass
+    return out
+
+def _is_wsl() -> bool:
+    try:
+        rel = platform.uname().release.lower()
+        if "microsoft" in rel or "wsl" in rel:
+            return True
+    except Exception:
+        pass
+    if os.environ.get("WSL_DISTRO_NAME"):
+        return True
+    if os.path.exists("/proc/sys/fs/binfmt_misc/WSLInterop"):
+        return True
+    return False
+
+def _wsl_to_windows_paths(files):
+    win = []
+    for p in files:
+        try:
+            win.append(subprocess.check_output(["wslpath", "-w", p], text=True).strip())
+        except Exception:
+            pass
+    return win
+
+# ---------- runners -----------------------------------------------------------
+
+def _run_windows_via_helper(ps1_windows_path, files_windows):
+    if not ps1_windows_path:
+        return False, "missing windows helper path"
+    cmd = [
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-STA",
+        "-File", ps1_windows_path,
+        *files_windows,
+    ]
+    try:
+        cp = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return True, (cp.stdout.strip() or "OK")
+    except subprocess.CalledProcessError as e:
+        return False, (e.stderr or e.stdout or str(e))
+
+def _run_windows_native(files):
+    here = os.path.dirname(__file__)
+    ps = os.path.abspath(os.path.join(here, os.pardir, "native_helpers", "windows", "copy_files.ps1"))
+    # When the server itself is Windows, the path is already Windows-y enough
+    return _run_windows_via_helper(ps, files)
+
+def _run_wsl_bridge(files):
+    # Convert the helper path + each file path to Windows and call powershell.exe from WSL
+    here = os.path.dirname(__file__)
+    ps_wsl = os.path.abspath(os.path.join(here, os.pardir, "native_helpers", "windows", "copy_files.ps1"))
+    try:
+        ps_win = subprocess.check_output(["wslpath", "-w", ps_wsl], text=True).strip()
+    except Exception as e:
+        return False, f"wslpath failed for helper: {e}"
+    files_win = _wsl_to_windows_paths(files)
+    if not files_win:
+        return False, "Could not convert any file paths to Windows paths"
+    return _run_windows_via_helper(ps_win, files_win)
+
+def _run_linux_gnome(files):
+    here = os.path.dirname(__file__)
+    py = os.path.abspath(os.path.join(here, os.pardir, "native_helpers", "linux", "gnome_copy_files.py"))
+    if not os.path.isfile(py):
+        return False, "missing linux helper (gnome_copy_files.py)"
+    env = os.environ.copy()
+    cmd = [sys.executable, py, *files]
+    try:
+        cp = subprocess.run(cmd, capture_output=True, text=True, env=env, check=True)
+        return True, cp.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        return False, (e.stderr or e.stdout or str(e))
+
+# ---------- route -------------------------------------------------------------
+
+@app.route("/api/copy_files_to_clipboard", methods=["POST"])
+def copy_files_to_clipboard():
+    data = request.get_json(silent=True) or {}
+    paths = data.get("paths", [])
+    if not paths:
+        return jsonify({"ok": False, "error": "No paths provided"}), 400
+
+    files = _resolve_files(paths)
+    if not files:
+        return jsonify({"ok": False, "error": "No files resolved"}), 400
+
+    sysname = platform.system().lower()
+    if sysname == "linux" and _is_wsl():
+        ok, msg = _run_wsl_bridge(files)
+        os_name = "wsl-bridge"
+    elif sysname == "windows":
+        ok, msg = _run_windows_native(files)
+        os_name = "windows"
+    elif sysname == "linux":
+        ok, msg = _run_linux_gnome(files)
+        os_name = "linux"
+    else:
+        return jsonify({"ok": False, "error": f"Unsupported OS: {sysname}"}), 400
+
+    if ok:
+        _ok("FILES COPIED TO OS CLIPBOARD", count=len(files), os=os_name)
+        return jsonify({"ok": True, "message": msg, "count": len(files)})
+    else:
+        _err("CLIPBOARD COPY FAILED", os=os_name, error=msg)
+        return jsonify({"ok": False, "error": msg}), 500

--- a/graph_fs/api/zip_routes.py
+++ b/graph_fs/api/zip_routes.py
@@ -1,0 +1,38 @@
+
+import io, os, time, zipfile
+from flask import Response, request
+from ..server import app, fs, _ok
+
+@app.route("/api/zip_files", methods=["POST"])
+def zip_files():
+    """
+    Build a zip containing the provided absolute file paths (validated under roots).
+    Request: { "paths": ["/abs/file1", "/abs/file2", ...] }
+    Response: application/zip (download)
+    """
+    data = request.get_json(silent=True) or {}
+    paths = data.get("paths", [])
+    if not paths:
+        return {"error": "No paths provided"}, 400
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in paths:
+            try:
+                resolved = fs.resolve(p)
+                if not os.path.isfile(resolved):
+                    continue
+                arcname = os.path.basename(resolved)  # change if you want to preserve subpaths
+                zf.write(resolved, arcname)
+            except Exception:
+                # Skip anything we can't safely include
+                continue
+
+    buf.seek(0)
+    _ok("ZIP BUILT", count=len(paths))
+    filename = f"scripts-{int(time.time())}.zip"
+    return Response(
+        buf.getvalue(),
+        mimetype="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/graph_fs/frontend/main/sidebar/files-panel.js
+++ b/graph_fs/frontend/main/sidebar/files-panel.js
@@ -1,13 +1,14 @@
-// sidebar/files-panel.js - Event-driven selection (no polling) + robust clipboard
+// sidebar/files-panel.js — Event-driven selection UI for Files panel
+// Adds: robust clipboard, Save to Folder, Download ZIP, and **Copy as Files (native OS clipboard)**
 
 export class FilesPanel {
     constructor() {
         this.filesContentEl = null;
         this.countBadge = null;
-        this.selectedFiles = []; // Ordered list
+        this.selectedFiles = []; // Ordered absolute paths
         this.draggedIndex = null;
 
-        // File extensions we can copy as text
+        // Text-like extensions we can safely read/concat as text
         this.textExtensions = new Set([
             '.js', '.py', '.txt', '.md', '.json', '.html', '.css', '.jsx', '.ts', '.tsx',
             '.yaml', '.yml', '.xml', '.sh', '.bash', '.sql', '.java', '.c', '.cpp', '.h',
@@ -25,24 +26,20 @@ export class FilesPanel {
             this.syncFromGraph(files);
         });
 
-        // Back-compat: still expose a direct API if nodes.js wants to call it
-        window.updateFilesPanel = (filesSet) => {
-            this.syncFromGraph(filesSet);
-        };
+        // Back-compat: allow nodes.js to call directly
+        window.updateFilesPanel = (filesSet) => this.syncFromGraph(filesSet);
 
-        // Initial paint
+        // First paint
         this.render();
     }
 
-    // ---- HTTP-safe clipboard helpers ---------------------------------------
+    // ---------------- Clipboard / download helpers ----------------
 
     async copyTextBestEffort(text) {
-        // 1) Modern Clipboard API on secure contexts (HTTPS/localhost)
-        if (window.isSecureContext && navigator.clipboard && navigator.clipboard.writeText) {
+        if (window.isSecureContext && navigator.clipboard?.writeText) {
             await navigator.clipboard.writeText(text);
             return true;
         }
-        // 2) Legacy fallback using hidden <textarea> + execCommand('copy') — works on HTTP
         const ta = document.createElement('textarea');
         ta.value = text;
         ta.setAttribute('readonly', '');
@@ -53,14 +50,8 @@ export class FilesPanel {
         ta.focus();
         ta.select();
         let ok = false;
-        try {
-            ok = document.execCommand('copy');
-        } finally {
-            document.body.removeChild(ta);
-        }
+        try { ok = document.execCommand('copy'); } finally { document.body.removeChild(ta); }
         if (ok) return true;
-
-        // 3) If all else fails, throw so caller can trigger the download fallback
         throw new Error('Clipboard not available in this context');
     }
 
@@ -72,27 +63,22 @@ export class FilesPanel {
         a.download = filename;
         document.body.appendChild(a);
         a.click();
-        document.body.removeChild(a);
+        a.remove();
         URL.revokeObjectURL(url);
     }
 
-    // ------------------------------------------------------------------------
+    // ---------------- Selection sync / mutations -------------------
 
     syncFromGraph(filesSet) {
         const graphFiles = Array.from(filesSet);
-
-        // Preserve order for existing files, add new ones to end
         const newFiles = graphFiles.filter(f => !this.selectedFiles.includes(f));
         const next = [
             ...this.selectedFiles.filter(f => filesSet.has(f)),
             ...newFiles
         ];
-
-        // Avoid unnecessary DOM work if nothing changed
         const same =
             next.length === this.selectedFiles.length &&
             next.every((v, i) => v === this.selectedFiles[i]);
-
         if (!same) {
             this.selectedFiles = next;
             this.render();
@@ -101,27 +87,19 @@ export class FilesPanel {
 
     removeFile(path) {
         this.selectedFiles = this.selectedFiles.filter(p => p !== path);
-
-        // Tell the graph to deselect this node
-        document.dispatchEvent(new CustomEvent('graphfs:deselect_file', {
-            detail: { path }
-        }));
-
+        document.dispatchEvent(new CustomEvent('graphfs:deselect_file', { detail: { path } }));
         this.render();
-
-        if (window.logEvent) {
-            window.logEvent(`[files] removed "${this.basename(path)}" from selection`);
-        }
+        window.logEvent?.(`[files] removed "${this.basename(path)}" from selection`);
     }
 
     moveFile(fromIndex, toIndex) {
         if (fromIndex === toIndex) return;
-
         const [movedFile] = this.selectedFiles.splice(fromIndex, 1);
         this.selectedFiles.splice(toIndex, 0, movedFile);
-
         this.render();
     }
+
+    // ---------------- Type helpers -------------------
 
     isTextFile(path) {
         const dot = path.lastIndexOf('.');
@@ -129,35 +107,34 @@ export class FilesPanel {
         return this.textExtensions.has(ext);
     }
 
-    async copyScripts() {
-        const textFiles = this.selectedFiles.filter(path => this.isTextFile(path));
+    basename(path) {
+        const parts = (path || '').split(/[/\\]/).filter(Boolean);
+        return parts.length ? parts[parts.length - 1] : path;
+    }
 
+    // ---------------- Actions -------------------
+
+    async copyScripts() {
+        const textFiles = this.selectedFiles.filter(p => this.isTextFile(p));
         if (textFiles.length === 0) {
             alert('No text files selected. Select .py, .js, .txt, etc.');
             return;
         }
 
         try {
-            // Request file contents from server
             const response = await fetch('/api/read_files', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ paths: textFiles })
             });
-
-            if (!response.ok) {
-                throw new Error('Failed to read files from server');
-            }
-
+            if (!response.ok) throw new Error('Failed to read files from server');
             const data = await response.json();
 
-            // Format as numbered scripts
             let output = '';
             data.files.forEach((fileData, idx) => {
                 const relativePath = window.toDisplayPath
                     ? window.toDisplayPath(fileData.path)
                     : this.basename(fileData.path);
-
                 output += `SCRIPT ${idx + 1}: ${relativePath}\n\n`;
                 output += fileData.content ?? '';
                 output += '\n\n\n\n';
@@ -166,9 +143,8 @@ export class FilesPanel {
             try {
                 await this.copyTextBestEffort(output);
                 this.showSuccessMessage(`Copied ${textFiles.length} script${textFiles.length > 1 ? 's' : ''}!`);
-                if (window.logEvent) window.logEvent(`[files] copied ${textFiles.length} scripts to clipboard`);
-            } catch (_copyErr) {
-                // Final fallback: offer a download so users can still get the content
+                window.logEvent?.(`[files] copied ${textFiles.length} scripts to clipboard`);
+            } catch {
                 this.downloadTextFile(`scripts-${Date.now()}.txt`, output);
                 this.showSuccessMessage('Saved scripts as a file (clipboard not available)');
             }
@@ -178,8 +154,113 @@ export class FilesPanel {
         }
     }
 
+    async copyPaths() {
+        const paths = this.selectedFiles.join('\n');
+        try {
+            await this.copyTextBestEffort(paths);
+            this.showSuccessMessage(`Copied ${this.selectedFiles.length} path${this.selectedFiles.length > 1 ? 's' : ''}!`);
+            window.logEvent?.(`[files] copied ${this.selectedFiles.length} file paths`);
+        } catch {
+            this.downloadTextFile(`paths-${Date.now()}.txt`, paths);
+            this.showSuccessMessage('Saved paths as a file (clipboard not available)');
+        }
+    }
+
+    // NEW: Copy selected files to the OS clipboard as real files (Windows / GNOME)
+    async copyAsFilesToClipboard() {
+        if (this.selectedFiles.length === 0) {
+            alert('No files selected.');
+            return;
+        }
+        try {
+            const resp = await fetch('/api/copy_files_to_clipboard', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ paths: this.selectedFiles })
+            });
+            const j = await resp.json().catch(() => ({}));
+            if (!resp.ok || !j.ok) throw new Error(j.error || 'Clipboard helper failed');
+            this.showSuccessMessage(`Copied ${j.count} file${j.count > 1 ? 's' : ''} to OS clipboard`);
+            window.logEvent?.(`[files] copied ${j.count} files to OS clipboard`);
+        } catch (err) {
+            console.error('Copy as files error:', err);
+            alert(`Failed to copy files to clipboard: ${err.message}`);
+        }
+    }
+
+    // Save selected text files to a user-chosen folder (Chromium)
+    async saveToFolder() {
+        const textFiles = this.selectedFiles.filter(p => this.isTextFile(p));
+        if (textFiles.length === 0) {
+            alert('No text files selected. Select .py, .js, .txt, etc.');
+            return;
+        }
+        if (!window.showDirectoryPicker) {
+            alert('Your browser does not support saving to folders. Try Chrome or Edge.');
+            return;
+        }
+
+        let dirHandle;
+        try { dirHandle = await window.showDirectoryPicker(); } catch { return; }
+
+        const resp = await fetch('/api/read_files', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ paths: textFiles })
+        });
+        if (!resp.ok) {
+            const j = await resp.json().catch(() => ({}));
+            throw new Error(j.error || 'Failed to read files');
+        }
+        const data = await resp.json();
+
+        for (const f of data.files) {
+            const name = this.basename(f.path);
+            const handle = await dirHandle.getFileHandle(name, { create: true });
+            const writable = await handle.createWritable();
+            await writable.write(f.content ?? '');
+            await writable.close();
+        }
+
+        this.showSuccessMessage(`Saved ${data.files.length} file${data.files.length > 1 ? 's' : ''} to folder`);
+        window.logEvent?.(`[files] saved ${data.files.length} files via File System Access API`);
+    }
+
+    // Download selected text files as a ZIP
+    async downloadZip() {
+        const textFiles = this.selectedFiles.filter(p => this.isTextFile(p));
+        if (textFiles.length === 0) {
+            alert('No text files selected.');
+            return;
+        }
+
+        const resp = await fetch('/api/zip_files', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ paths: textFiles })
+        });
+        if (!resp.ok) {
+            const j = await resp.json().catch(() => ({}));
+            throw new Error(j.error || 'Failed to zip files');
+        }
+
+        const blob = await resp.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `scripts-${Date.now()}.zip`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+
+        this.showSuccessMessage('Downloaded ZIP');
+        window.logEvent?.('[files] downloaded ZIP of selected files');
+    }
+
+    // ---------------- UI rendering -------------------
+
     showSuccessMessage(message) {
-        // Create floating success notification
         const notification = document.createElement('div');
         notification.className = 'copy-success-notification';
         notification.textContent = `✓ ${message}`;
@@ -194,7 +275,6 @@ export class FilesPanel {
     render() {
         if (!this.filesContentEl) return;
 
-        // Update count badge
         if (this.countBadge) {
             this.countBadge.textContent = this.selectedFiles.length;
         }
@@ -206,12 +286,10 @@ export class FilesPanel {
 
         const textFileCount = this.selectedFiles.filter(p => this.isTextFile(p)).length;
 
-        // Render ordered file list with drag handles
         const filesList = this.selectedFiles.map((path, idx) => {
             const name = this.basename(path);
             const displayPath = window.toDisplayPath ? window.toDisplayPath(path) : path;
             const isText = this.isTextFile(path);
-
             return `
                 <div class="file-item orderable" data-index="${idx}" draggable="true">
                     <div class="file-number">${idx + 1}</div>
@@ -226,51 +304,44 @@ export class FilesPanel {
             `;
         }).join('');
 
+        const disabledIfNone = this.selectedFiles.length === 0 ? 'disabled' : '';
+        const disabledClassIfNone = this.selectedFiles.length === 0 ? 'disabled' : '';
+        const disabledIfNoText = textFileCount === 0 ? 'disabled' : '';
+        const disabledClassIfNoText = textFileCount === 0 ? 'disabled' : '';
+
         this.filesContentEl.innerHTML = `
             <div class="files-list">
                 ${filesList}
             </div>
             <div class="files-actions">
-                <button id="copy-paths-btn" class="action-btn">📋 Copy Paths</button>
-                <button id="copy-scripts-btn" class="action-btn ${textFileCount === 0 ? 'disabled' : ''}"
-                        ${textFileCount === 0 ? 'disabled' : ''}>
-                    📝 Copy Scripts (${textFileCount})
-                </button>
+                <button id="copy-paths-btn" class="action-btn ${disabledClassIfNone}" ${disabledIfNone}>📋 Copy Paths</button>
+                <button id="copy-files-btn" class="action-btn ${disabledClassIfNone}" ${disabledIfNone}>📁 Copy as Files</button>
+                <button id="copy-scripts-btn" class="action-btn ${disabledClassIfNoText}" ${disabledIfNoText}>📝 Copy Scripts (${textFileCount})</button>
+                <button id="save-to-folder-btn" class="action-btn ${disabledClassIfNoText}" ${disabledIfNoText}>📂 Save to Folder</button>
+                <button id="download-zip-btn" class="action-btn ${disabledClassIfNoText}" ${disabledIfNoText}>📦 Download ZIP</button>
             </div>
         `;
 
-        // Attach event handlers
         this.attachHandlers();
     }
 
     attachHandlers() {
-        // Copy paths button
-        const copyPathsBtn = document.getElementById('copy-paths-btn');
-        if (copyPathsBtn) {
-            copyPathsBtn.addEventListener('click', () => this.copyPaths());
-        }
+        document.getElementById('copy-paths-btn')?.addEventListener('click', () => this.copyPaths());
+        document.getElementById('copy-files-btn')?.addEventListener('click', () => this.copyAsFilesToClipboard());
+        document.getElementById('copy-scripts-btn')?.addEventListener('click', () => this.copyScripts());
+        document.getElementById('save-to-folder-btn')?.addEventListener('click', () => this.saveToFolder());
+        document.getElementById('download-zip-btn')?.addEventListener('click', () => this.downloadZip());
 
-        // Copy scripts button
-        const copyScriptsBtn = document.getElementById('copy-scripts-btn');
-        if (copyScriptsBtn) {
-            copyScriptsBtn.addEventListener('click', () => this.copyScripts());
-        }
-
-        // Remove file buttons
         this.filesContentEl.querySelectorAll('.remove-file').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const path = e.currentTarget.dataset.path;
-                this.removeFile(path);
-            });
+            btn.addEventListener('click', (e) => this.removeFile(e.currentTarget.dataset.path));
         });
 
-        // Drag and drop handlers
         const items = this.filesContentEl.querySelectorAll('.file-item.orderable');
         items.forEach(item => {
             item.addEventListener('dragstart', (e) => this.handleDragStart(e));
-            item.addEventListener('dragover', (e) => this.handleDragOver(e));
-            item.addEventListener('drop', (e) => this.handleDrop(e));
-            item.addEventListener('dragend', (e) => this.handleDragEnd(e));
+            item.addEventListener('dragover',  (e) => this.handleDragOver(e));
+            item.addEventListener('drop',      (e) => this.handleDrop(e));
+            item.addEventListener('dragend',   (e) => this.handleDragEnd(e));
         });
     }
 
@@ -283,55 +354,25 @@ export class FilesPanel {
     handleDragOver(e) {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
-
         const item = e.currentTarget;
-        if (!item.classList.contains('dragging')) {
-            item.classList.add('drag-over');
-        }
+        if (!item.classList.contains('dragging')) item.classList.add('drag-over');
     }
 
     handleDrop(e) {
         e.preventDefault();
         e.stopPropagation();
-
         const targetIndex = parseInt(e.currentTarget.dataset.index, 10);
-
         if (this.draggedIndex !== null && this.draggedIndex !== targetIndex) {
             this.moveFile(this.draggedIndex, targetIndex);
         }
-
         e.currentTarget.classList.remove('drag-over');
     }
 
     handleDragEnd(e) {
         e.currentTarget.classList.remove('dragging');
-
-        // Remove all drag-over classes
-        this.filesContentEl.querySelectorAll('.file-item').forEach(item => {
-            item.classList.remove('drag-over');
-        });
-
+        this.filesContentEl.querySelectorAll('.file-item').forEach(i => i.classList.remove('drag-over'));
         this.draggedIndex = null;
     }
 
-    async copyPaths() {
-        const paths = this.selectedFiles.join('\n');
-        try {
-            await this.copyTextBestEffort(paths);
-            this.showSuccessMessage(`Copied ${this.selectedFiles.length} path${this.selectedFiles.length > 1 ? 's' : ''}!`);
-            if (window.logEvent) window.logEvent(`[files] copied ${this.selectedFiles.length} file paths`);
-        } catch (_copyErr) {
-            this.downloadTextFile(`paths-${Date.now()}.txt`, paths);
-            this.showSuccessMessage('Saved paths as a file (clipboard not available)');
-        }
-    }
-
-    basename(path) {
-        const parts = (path || '').split(/[/\\]/).filter(Boolean);
-        return parts.length ? parts[parts.length - 1] : path;
-    }
-
-    onActivate() {
-        this.render();
-    }
+    onActivate() { this.render(); }
 }

--- a/graph_fs/native_helpers/linux/gnome_copy_files.py
+++ b/graph_fs/native_helpers/linux/gnome_copy_files.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Requires: python3-gi, gir1.2-gtk-3.0
+# Sets the GNOME/Nautilus clipboard target 'x-special/gnome-copied-files'
+# with "copy\nfile:///..." payload so you can Paste in Nautilus/Nemo/Caja.
+
+import sys, os, urllib.parse
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
+
+def file_uri(p: str) -> str:
+    return "file://" + urllib.parse.quote(os.path.abspath(p))
+
+def main(argv):
+    # argv are absolute paths from the server
+    paths = [os.path.abspath(p) for p in argv if os.path.isfile(p)]
+    if not paths:
+        print("No files to copy.", file=sys.stderr)
+        return 1
+
+    payload = "copy\n" + "\n".join(file_uri(p) for p in paths)
+
+    cb = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+    def _get_func(clipboard, selection, info, data):
+        selection.set(selection.get_target(), 8, payload.encode("utf-8"))
+    cb.set_with_data(
+        targets=[Gtk.TargetEntry.new("x-special/gnome-copied-files", 0, 0)],
+        get_func=_get_func,
+        clear_func=lambda clipboard, data: None,
+        user_data=None,
+    )
+    cb.store()  # persist after process exit
+
+    print(f"Copied {len(paths)} file(s) to clipboard for GNOME Paste.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/graph_fs/native_helpers/windows/copy_files.ps1
+++ b/graph_fs/native_helpers/windows/copy_files.ps1
@@ -1,0 +1,35 @@
+# Copy multiple files to Windows clipboard
+# Usage: powershell.exe -NoProfile -ExecutionPolicy Bypass -STA -File copy_files.ps1 "C:\file1.txt" "C:\file2.txt"
+
+param(
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$FilePaths
+)
+
+# Filter to only existing files
+$validFiles = $FilePaths | Where-Object { Test-Path $_ -PathType Leaf } | ForEach-Object { Get-Item $_ }
+
+if ($validFiles.Count -eq 0) {
+    Write-Error "No valid files provided"
+    exit 1
+}
+
+try {
+    Add-Type -AssemblyName System.Windows.Forms
+    
+    # Create a StringCollection containing the file paths
+    $fileCollection = New-Object System.Collections.Specialized.StringCollection
+    foreach ($file in $validFiles) {
+        $fileCollection.Add($file.FullName)
+    }
+    
+    # Copy to clipboard using the FileDrop format
+    [System.Windows.Forms.Clipboard]::SetFileDropList($fileCollection)
+    
+    Write-Host "Successfully copied $($validFiles.Count) file(s) to clipboard"
+    exit 0
+}
+catch {
+    Write-Error "Failed to copy files to clipboard: $_"
+    exit 1
+}


### PR DESCRIPTION
…), API + UI; fix server routing**

* Add **/api/copy_files_to_clipboard** with OS-aware backends

  * **Windows native**: call `copy_files.ps1` in STA via `powershell.exe -NoProfile -ExecutionPolicy Bypass -STA -File …`
  * **WSL bridge**: detect WSL, convert WSL paths → Windows with `wslpath -w`, run PowerShell so files land in the **Windows** clipboard
  * **Linux GNOME**: `gnome_copy_files.py` sets `x-special/gnome-copied-files` target via GTK clipboard
  * Robust path resolution through `fs.resolve`; structured logging (`_ok/_err`) and JSON responses

* **Frontend (FilesPanel)**

  * New **“📁 Copy as Files”** button -> POSTs selected absolute paths to `/api/copy_files_to_clipboard`
  * Keep **Copy Paths** and **Copy Scripts (N)** (with HTTPS clipboard + execCommand fallback); add **Save to Folder** (FS Access API) and **Download ZIP**
  * Ordered, draggable selected list; success toasts; graceful error handling
  * Wire static entry: `frontend/index.js` imports `tree-overlay.js`

* **Server**

  * Disable Flask’s built-in static and serve frontend **after** API/event registration to prevent `/api/*` being shadowed (fixes 405)
  * Enable CORS; Socket.IO threading mode; expose `index()` + `/<path:filename>` for assets
  * Startup restoration of previously active roots

* **Helpers**

  * `copy_files.ps1`: sets **FileDrop** only (no text), avoids emitting raw paths; prints concise success message
  * `gnome_copy_files.py`: clean CLI helper; persists clipboard with `store()`

* **UX note**

  * “Copy as Files” is for pasting into **Explorer / VS Code Explorer / file targets**; use “Copy Scripts (N)” for pasting **text** into editors/chats.

**Why:** allow true OS-level file pasting from GraphFS selections, including seamless Windows paste when the backend runs inside WSL. Also fixes API routing so clipboard endpoint works reliably.

**Manual tests**

* Windows + WSL: select files → **Copy as Files** → paste into Explorer & VS Code Explorer ✅
* Linux GNOME: paste into Nautilus/Nemo/Caja ✅
* Copy Scripts pastes concatenated numbered scripts into text fields ✅
* API no longer 405; returns structured OK/ERR ✅

Refs: #clipboard #wsl #gnome #ux #server-routing